### PR TITLE
Demo Result -> exception conversion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,28 @@ int main()
   const auto compositeStruct = rust_cxx_build_composite(XY{.x = 0, .y = 1}, std::numbers::pi);
   std::cout << std::format("Composite struct values: {},{},{}\n", compositeStruct.point.x, compositeStruct.point.y, compositeStruct.value);
 
-  // Function that relies on system libraries
-  const auto getResponse = std::string(rust_cxx_http_get("https://httpbin.org/get", ""));
-  std::cout << std::format("GET: {}\n", getResponse);
+  // Function that relies on system libraries, and throws an exception on error
+  try
+  {
+    const auto getResponse = std::string(rust_cxx_http_get("https://httpbin.org/get", ""));
+    std::cout << std::format("HTTP BIN GET: {}\n", getResponse);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << std::format("HTTP BIN GET failed: {}\n", e.what());
+  }
+
+  // Again with an invalid URL to demonstrate rust Result errors being turned into exceptions
+  try
+  {
+    const auto getResponse = std::string(rust_cxx_http_get("this isn't a valid url", ""));
+    std::cerr << std::format("Invalid url, we shouldn't see this message!: {}\n", getResponse);
+  }
+  catch (const std::exception &e)
+  {
+    // Expected outcome
+    std::cout << std::format("Invalid url failed: {}\n", e.what());
+  }
 
   return 0;
 }

--- a/src/rust_lib/src/lib.rs
+++ b/src/rust_lib/src/lib.rs
@@ -29,8 +29,9 @@ mod ffi {
 
         fn rust_cxx_build_composite(point: XY, value: f64) -> CompositeStructure;
 
-        fn rust_cxx_wow(message: &str) -> Result<String>;
+        fn rust_cxx_wow(message: &str) -> String;
 
+        // This returns a Result type, which is mapped to a C++ exception on error
         fn rust_cxx_http_get(url: &str, body: &str) -> Result<String>;
     }
 }
@@ -67,8 +68,8 @@ fn rust_cxx_build_composite(point: XY, value: f64) -> CompositeStructure {
     }
 }
 
-pub fn rust_cxx_wow(message: &str) -> Result<String> {
-    Ok(format!("{}. wow.", message))
+pub fn rust_cxx_wow(message: &str) -> String {
+    format!("{}. wow.", message)
 }
 
 pub fn rust_cxx_http_get(url: &str, body: &str) -> Result<String> {
@@ -81,5 +82,5 @@ pub fn rust_cxx_http_get(url: &str, body: &str) -> Result<String> {
     let mut buf = Vec::new();
     res.copy_to(&mut buf)?;
 
-    Ok(std::str::from_utf8(buf.as_slice()).unwrap().to_string())
+    Ok(std::str::from_utf8(buf.as_slice()).map(|s| s.to_string())?)
 }


### PR DESCRIPTION
- Remove unnecessary Result from function. 
- Show example of Result being converted to an exception on the C++ side (in the http_get method).